### PR TITLE
fix story content display

### DIFF
--- a/app/assets/stylesheets/components/_story-card.scss
+++ b/app/assets/stylesheets/components/_story-card.scss
@@ -43,11 +43,13 @@
     margin-top: 16px;
     font-family: 'Poppins';
     font-weight: lighter;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
     overflow: hidden;
-    text-overflow: ellipsis;
-    height: 100%;
   }
 }
+
 
 .story-card-row-up {
   height: 60%;


### PR DESCRIPTION
Avant...
<img width="442" alt="Capture d’écran 2021-05-28 à 12 05 45" src="https://user-images.githubusercontent.com/81431632/119967931-296a1e80-bfad-11eb-8ea8-c5a18743aba0.png">

Après!
<img width="483" alt="Capture d’écran 2021-05-28 à 12 05 20" src="https://user-images.githubusercontent.com/81431632/119967969-338c1d00-bfad-11eb-897d-437253c51d99.png">
